### PR TITLE
Enable unit parsing with pint package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 beautifulsoup4
 requests
+pint

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/simon-andrews/umass-toolkit",
     packages=setuptools.find_packages(),
-    install_requires=['requests', 'beautifulsoup4'],
+    install_requires=['requests', 'beautifulsoup4', 'pint'],
     classifiers=(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',

--- a/umass_toolkit/dining.py
+++ b/umass_toolkit/dining.py
@@ -7,7 +7,7 @@ import requests
 import dining_utils
 import pint
 
-ureg = pint.UnitRegistry()
+_ureg = pint.UnitRegistry()
 
 def get_locations():
     locations = requests.get('https://www.umassdining.com/uapp/get_infov2').json()
@@ -62,7 +62,7 @@ def _menu_html_to_dict(html_string):
                                         'total-carb', 'total-fat', 'trans-fat']:
                     if data == '':
                         continue
-                    data = ureg.Quantity(data)
+                    data = _ureg.Quantity(data)
                 ret[item_name][attribute_name] = data
     return ret
 


### PR DESCRIPTION
Returns elements of type `Quantity` for applicable attributes. For now
calories are left as ints. Adds `pint` to package dependencies.

Resolves #12 